### PR TITLE
Add NFS kstat collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Simple set of [diamond](https://github.com/python-diamond) collectors that use S
   * Collects virtual filesystem statistics for any mount in /etc/mnttab that produces metrics.
 * SolarisARCCollector
   * Collects all ARC statistics for the system.
+* SolarisNFSCollector
+  * Collects NFS statistics for the system.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
 
 setup(
     name = "diamond-solariskstat",
-    version = "0.1",
+    version = "0.2",
     package_dir = {'': 'src'},
     packages = find_packages(),
     data_files = data_files,

--- a/src/collectors/solariskstat/solarisnfs.py
+++ b/src/collectors/solariskstat/solarisnfs.py
@@ -1,0 +1,42 @@
+import subprocess
+import diamond.collector
+
+class SolarisNFSCollector(diamond.collector.Collector):
+
+  def get_default_config(self):
+      """
+      Returns the default collector settings
+      """
+      config = super(SolarisNFSCollector, self).get_default_config()
+      config.update({
+          'enabled':  'True',
+          'path':     'kstats',
+      })
+      return config
+
+  def collect(self):
+
+    self.collectnfs('v3')
+    self.collectnfs('v4')
+    self.collectnfs('rpc')
+
+  def collectnfs(self, version):
+
+    prefix = 'nfs.' + str(version) + "."
+    command = {
+      'v3': "kstat -p nfs:*:rfsproccnt_v3",
+      'v4': "kstat -p nfs:*:nfs4* -p nfs:*:rfsproccnt_v4",
+      'rpc': "kstat -p unix:*:rpc_cots_server -p nfs:0:nfs_server"
+    }
+
+    metrics = dict()
+
+    stats = subprocess.Popen(command.get(str(version)), shell=True, stdout=subprocess.PIPE).stdout.readlines()
+    for line in stats:
+      metric = line.split(':')[-1].split('\t')
+      metrics.update({metric[0]:metric[1].strip()})
+
+    metrics.pop('class')
+
+    for m in metrics:
+      self.publish(prefix + m, metrics[m])


### PR DESCRIPTION
Since diamond's nfs collector relies on /proc/net/, which doesn't exist
in solaris, this adds a collector to read the metrics from kstat.
